### PR TITLE
Enhance Tool Registry with custom scripts and validation

### DIFF
--- a/ph_agent/agent/tools/tool_manager.py
+++ b/ph_agent/agent/tools/tool_manager.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field, create_model
 logger = logging.getLogger(__name__)
 
 
-# Safe namespace for executing custom/server scripts.
+# Safe namespace for executing custom scripts.
 # Provides controlled access to common modules without dangerous builtins.
 SAFE_NAMESPACE = {
     "__builtins__": {
@@ -124,7 +124,7 @@ class ToolManager:
             filters={"is_enabled": 1},
             fields=[
                 "name", "tool_name", "description", "script_type",
-                "python_function", "custom_script", "server_script",
+                "python_function", "custom_script",
                 "parameters_json", "requires_approval"
             ]
         )
@@ -161,8 +161,6 @@ class ToolManager:
         
         if script_type == "Custom Script":
             return cls._register_custom_script_tool(record)
-        elif script_type == "Server Script":
-            return cls._register_server_script_tool(record)
         else:
             return cls._register_existing_function_tool(record)
     
@@ -323,61 +321,6 @@ class ToolManager:
             )
         
         # Otherwise use the @tool decorator which infers from type hints
-        return tool(**tool_kwargs)(run_tool_func)
-    
-    @classmethod
-    def _register_server_script_tool(cls, record: Dict[str, Any]):
-        """
-        Register a tool backed by a Frappe Server Script.
-        
-        Fetches the Server Script document by name, reads its ``script`` field,
-        and expects a top-level ``run_tool`` function.
-        """
-        server_script_name = record.get("server_script", "")
-        if not server_script_name:
-            raise ValueError(f"Tool '{record['tool_name']}' has no server script link.")
-        
-        if not frappe.db.exists("Server Script", server_script_name):
-            raise ValueError(f"Server Script '{server_script_name}' not found for tool '{record['tool_name']}'.")
-        
-        server_script_doc = frappe.get_doc("Server Script", server_script_name)
-        script_code = server_script_doc.get("script", "")
-        if not script_code:
-            raise ValueError(f"Server Script '{server_script_name}' has no script content.")
-        
-        # Compile and exec in safe namespace
-        namespace = cls._get_safe_namespace()
-        try:
-            exec(script_code, namespace)
-        except Exception as e:
-            raise ValueError(
-                f"Failed to execute Server Script '{server_script_name}' for tool '{record['tool_name']}': {e}"
-            ) from e
-        
-        run_tool_func = namespace.get("run_tool")
-        if not callable(run_tool_func):
-            raise ValueError(
-                f"Server Script '{server_script_name}' must define a callable 'run_tool' function."
-            )
-        
-        # Build input model from parameters_json
-        parameters_json = record.get("parameters_json")
-        input_model = cls._build_input_model_from_schema(parameters_json)
-        
-        tool_kwargs = {
-            "name": record["tool_name"],
-            "description": record["description"] or "No description provided",
-        }
-        if record.get("requires_approval"):
-            tool_kwargs["approval_mode"] = "always_require"
-        
-        if input_model is not None:
-            return FunctionTool(
-                **tool_kwargs,
-                input_model=input_model,
-                func=run_tool_func,
-            )
-        
         return tool(**tool_kwargs)(run_tool_func)
     
     @classmethod

--- a/ph_agent/agent/tools/tool_manager.py
+++ b/ph_agent/agent/tools/tool_manager.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # Provides controlled access to common modules without dangerous builtins.
 SAFE_NAMESPACE = {
     "__builtins__": {
+        "__import__": __import__,
         "abs": abs,
         "all": all,
         "any": any,

--- a/ph_agent/agent/tools/tool_manager.py
+++ b/ph_agent/agent/tools/tool_manager.py
@@ -8,12 +8,75 @@ for use with the Microsoft Agent Framework.
 import importlib
 import json
 import logging
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, get_type_hints
 
 import frappe
 from agent_framework import FunctionInvocationContext, FunctionTool, tool
+from pydantic import BaseModel, Field, create_model
 
 logger = logging.getLogger(__name__)
+
+
+# Safe namespace for executing custom/server scripts.
+# Provides controlled access to common modules without dangerous builtins.
+SAFE_NAMESPACE = {
+    "__builtins__": {
+        "abs": abs,
+        "all": all,
+        "any": any,
+        "bool": bool,
+        "callable": callable,
+        "chr": chr,
+        "dict": dict,
+        "divmod": divmod,
+        "enumerate": enumerate,
+        "filter": filter,
+        "float": float,
+        "format": format,
+        "frozenset": frozenset,
+        "getattr": getattr,
+        "hasattr": hasattr,
+        "hash": hash,
+        "hex": hex,
+        "id": id,
+        "int": int,
+        "isinstance": isinstance,
+        "issubclass": issubclass,
+        "iter": iter,
+        "len": len,
+        "list": list,
+        "map": map,
+        "max": max,
+        "min": min,
+        "next": next,
+        "object": object,
+        "oct": oct,
+        "ord": ord,
+        "pow": pow,
+        "print": print,
+        "range": range,
+        "repr": repr,
+        "reversed": reversed,
+        "round": round,
+        "set": set,
+        "slice": slice,
+        "sorted": sorted,
+        "str": str,
+        "sum": sum,
+        "tuple": tuple,
+        "type": type,
+        "zip": zip,
+    },
+    "math": __import__("math"),
+    "datetime": __import__("datetime"),
+    "json": __import__("json"),
+    "random": __import__("random"),
+    "re": __import__("re"),
+    "decimal": __import__("decimal"),
+    "statistics": __import__("statistics"),
+    "frappe": frappe,
+    "FunctionInvocationContext": FunctionInvocationContext,
+}
 
 
 class ToolManager:
@@ -58,7 +121,11 @@ class ToolManager:
         tool_records = frappe.get_all(
             "Tool Registry",
             filters={"is_enabled": 1},
-            fields=["name", "tool_name", "description", "python_function", "parameters_json", "requires_approval"]
+            fields=[
+                "name", "tool_name", "description", "script_type",
+                "python_function", "custom_script", "server_script",
+                "parameters_json", "requires_approval"
+            ]
         )
         
         logger.info("Loading %d enabled tools from Tool Registry", len(tool_records))
@@ -81,11 +148,93 @@ class ToolManager:
         """
         Register a single tool from Tool Registry record.
         
+        Dispatches to the appropriate registration method based on script_type.
+        
         Args:
             record: Tool Registry document as dictionary
             
         Returns:
             Registered tool object or None if registration fails
+        """
+        script_type = record.get("script_type", "Existing Function")
+        
+        if script_type == "Custom Script":
+            return cls._register_custom_script_tool(record)
+        elif script_type == "Server Script":
+            return cls._register_server_script_tool(record)
+        else:
+            return cls._register_existing_function_tool(record)
+    
+    @classmethod
+    def _get_safe_namespace(cls) -> Dict[str, Any]:
+        """Return a copy of the safe namespace dict."""
+        return dict(SAFE_NAMESPACE)
+    
+    @classmethod
+    def _build_input_model_from_schema(cls, parameters_json: Optional[str]) -> Optional[type[BaseModel]]:
+        """
+        Build a Pydantic input model from a JSON Schema string.
+        
+        Args:
+            parameters_json: JSON Schema string describing tool parameters
+            
+        Returns:
+            A Pydantic BaseModel subclass, or None if no schema provided
+        """
+        if not parameters_json:
+            return None
+        
+        schema = json.loads(parameters_json)
+        properties = schema.get("properties", {})
+        required_fields = set(schema.get("required", []))
+        
+        fields = {}
+        for field_name, field_schema in properties.items():
+            field_type = cls._json_schema_type_to_python(field_schema)
+            field_description = field_schema.get("description", "")
+            
+            if field_name in required_fields:
+                # Required — use Field with no default
+                fields[field_name] = (
+                    field_type,
+                    Field(..., description=field_description),
+                )
+            else:
+                # Optional — wrap in Optional and set default None
+                default_value = field_schema.get("default", None)
+                fields[field_name] = (
+                    Optional[field_type],
+                    Field(default=default_value, description=field_description),
+                )
+        
+        if not fields:
+            return None
+        
+        return create_model("ToolInputModel", **fields)
+    
+    @classmethod
+    def _json_schema_type_to_python(cls, field_schema: Dict[str, Any]) -> type:
+        """Map JSON Schema types to Python types."""
+        json_type = field_schema.get("type", "string")
+        
+        type_map = {
+            "string": str,
+            "integer": int,
+            "number": float,
+            "boolean": bool,
+            "array": list,
+            "object": dict,
+        }
+        
+        return type_map.get(json_type, str)
+    
+    @classmethod
+    def _register_existing_function_tool(cls, record: Dict[str, Any]):
+        """
+        Register a tool backed by an existing Python function.
+        
+        This is the original behaviour: import a dotted function path and
+        wrap it with @tool.
         """
         try:
             # Import the function
@@ -125,6 +274,110 @@ class ToolManager:
         except Exception as e:
             logger.error("Unexpected error registering tool %s: %s", record["tool_name"], str(e))
             raise
+    
+    @classmethod
+    def _register_custom_script_tool(cls, record: Dict[str, Any]):
+        """
+        Register a tool backed by a Custom Script stored in the Tool Registry.
+        
+        The script must define a top-level ``run_tool`` function.
+        The ``parameters_json`` field provides the JSON Schema for LLM arguments.
+        """
+        script_code = record.get("custom_script", "")
+        if not script_code:
+            raise ValueError(f"Tool '{record['tool_name']}' has no custom script content.")
+        
+        # Compile and exec in safe namespace
+        namespace = cls._get_safe_namespace()
+        try:
+            exec(script_code, namespace)
+        except Exception as e:
+            raise ValueError(f"Failed to execute custom script for tool '{record['tool_name']}': {e}") from e
+        
+        run_tool_func = namespace.get("run_tool")
+        if not callable(run_tool_func):
+            raise ValueError(
+                f"Custom script for tool '{record['tool_name']}' must define a callable 'run_tool' function."
+            )
+        
+        # Build input model from parameters_json
+        parameters_json = record.get("parameters_json")
+        input_model = cls._build_input_model_from_schema(parameters_json)
+        
+        # Create approval kwargs
+        tool_kwargs = {
+            "name": record["tool_name"],
+            "description": record["description"] or "No description provided",
+        }
+        if record.get("requires_approval"):
+            tool_kwargs["approval_mode"] = "always_require"
+        
+        # If we have an input model (schema defined), use FunctionTool directly
+        # with the model so the LLM sees proper typed parameters.
+        if input_model is not None:
+            return FunctionTool(
+                **tool_kwargs,
+                input_model=input_model,
+                func=run_tool_func,
+            )
+        
+        # Otherwise use the @tool decorator which infers from type hints
+        return tool(**tool_kwargs)(run_tool_func)
+    
+    @classmethod
+    def _register_server_script_tool(cls, record: Dict[str, Any]):
+        """
+        Register a tool backed by a Frappe Server Script.
+        
+        Fetches the Server Script document by name, reads its ``script`` field,
+        and expects a top-level ``run_tool`` function.
+        """
+        server_script_name = record.get("server_script", "")
+        if not server_script_name:
+            raise ValueError(f"Tool '{record['tool_name']}' has no server script link.")
+        
+        if not frappe.db.exists("Server Script", server_script_name):
+            raise ValueError(f"Server Script '{server_script_name}' not found for tool '{record['tool_name']}'.")
+        
+        server_script_doc = frappe.get_doc("Server Script", server_script_name)
+        script_code = server_script_doc.get("script", "")
+        if not script_code:
+            raise ValueError(f"Server Script '{server_script_name}' has no script content.")
+        
+        # Compile and exec in safe namespace
+        namespace = cls._get_safe_namespace()
+        try:
+            exec(script_code, namespace)
+        except Exception as e:
+            raise ValueError(
+                f"Failed to execute Server Script '{server_script_name}' for tool '{record['tool_name']}': {e}"
+            ) from e
+        
+        run_tool_func = namespace.get("run_tool")
+        if not callable(run_tool_func):
+            raise ValueError(
+                f"Server Script '{server_script_name}' must define a callable 'run_tool' function."
+            )
+        
+        # Build input model from parameters_json
+        parameters_json = record.get("parameters_json")
+        input_model = cls._build_input_model_from_schema(parameters_json)
+        
+        tool_kwargs = {
+            "name": record["tool_name"],
+            "description": record["description"] or "No description provided",
+        }
+        if record.get("requires_approval"):
+            tool_kwargs["approval_mode"] = "always_require"
+        
+        if input_model is not None:
+            return FunctionTool(
+                **tool_kwargs,
+                input_model=input_model,
+                func=run_tool_func,
+            )
+        
+        return tool(**tool_kwargs)(run_tool_func)
     
     @classmethod
     def _inject_context_into_tools(cls, tools: List, session_name: Optional[str] = None, user: Optional[str] = None) -> List:

--- a/ph_agent/patches.txt
+++ b/ph_agent/patches.txt
@@ -3,4 +3,5 @@
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
 
 [post_model_sync]
+ph_agent.patches.v16_0.seed_tool_registry
 # Patches added in this section will be executed after doctypes are migrated

--- a/ph_agent/patches/v16_0/seed_tool_registry.py
+++ b/ph_agent/patches/v16_0/seed_tool_registry.py
@@ -1,0 +1,48 @@
+"""
+Migration patch to seed default Tool Registry entries.
+
+Creates the built-in tools (show_datetime, calculate) in the Tool Registry
+if they don't already exist.
+"""
+
+import frappe
+
+TOOL_REGISTRY_SEED = [
+    {
+        "doctype": "Tool Registry",
+        "tool_name": "show_datetime",
+        "is_enabled": 1,
+        "script_type": "Existing Function",
+        "description": "Shows the current date and time. Useful for testing tool registration and verifying the system is working.",
+        "python_function": "ph_agent.agent.tools.datetime_tool.show_datetime_tool",
+        "requires_approval": 0,
+    },
+    {
+        "doctype": "Tool Registry",
+        "tool_name": "calculate",
+        "is_enabled": 1,
+        "script_type": "Existing Function",
+        "description": "Performs mathematical calculations. Supports basic arithmetic, percentages, and common math functions.",
+        "python_function": "ph_agent.agent.tools.calculator_tool.calculate_tool",
+        "requires_approval": 0,
+    },
+]
+
+
+def execute():
+    """Seed default Tool Registry entries if they don't exist."""
+    for record in TOOL_REGISTRY_SEED:
+        tool_name = record["tool_name"]
+
+        # Check if already exists
+        if frappe.db.exists("Tool Registry", tool_name):
+            frappe.logger().info("Tool Registry entry '%s' already exists, skipping.", tool_name)
+            continue
+
+        try:
+            doc = frappe.get_doc(record)
+            doc.insert(ignore_permissions=True)
+            frappe.logger().info("Created Tool Registry entry: %s", tool_name)
+        except Exception as e:
+            frappe.logger().error("Failed to create Tool Registry entry '%s': %s", tool_name, str(e))
+            raise

--- a/ph_agent/patches/v16_0/seed_tool_registry.py
+++ b/ph_agent/patches/v16_0/seed_tool_registry.py
@@ -26,6 +26,16 @@ TOOL_REGISTRY_SEED = [
         "python_function": "ph_agent.agent.tools.calculator_tool.calculate_tool",
         "requires_approval": 0,
     },
+    {
+        "doctype": "Tool Registry",
+        "tool_name": "circle_calculator",
+        "is_enabled": 1,
+        "script_type": "Custom Script",
+        "description": "Calculate the area and circumference of a circle given its radius. Demonstrates the Custom Script feature.",
+        "custom_script": "import math\n\ndef run_tool(radius, unit=\"meters\", ctx=None):\n    \"\"\"\n    Calculate the area and circumference of a circle given its radius.\n\n    Parameters:\n        radius (float): The radius of the circle (required).\n        unit (str): Unit of measurement (default: \"meters\").\n        ctx: Function invocation context (injected by the framework).\n\n    Returns:\n        A formatted string with the area and circumference.\n    \"\"\"\n    area = math.pi * radius ** 2\n    circumference = 2 * math.pi * radius\n\n    context_info = \"\"\n    if ctx and hasattr(ctx, \"kwargs\"):\n        user = ctx.kwargs.get(\"user\", \"\")\n        session = ctx.kwargs.get(\"session_name\", \"\")\n        if user or session:\n            context_info = f\" [User: {user}, Session: {session}]\"\n\n    return (\n        f\"Circle (radius={radius} {unit}): \"\n        f\"Area = {area:.2f} sq. {unit}, \"\n        f\"Circumference = {circumference:.2f} {unit}{context_info}\"\n    )\n",
+        "parameters_json": "{\n  \"type\": \"object\",\n  \"properties\": {\n    \"radius\": {\n      \"type\": \"number\",\n      \"description\": \"The radius of the circle\"\n    },\n    \"unit\": {\n      \"type\": \"string\",\n      \"description\": \"Unit of measurement (e.g., meters, feet)\"\n    }\n  },\n  \"required\": [\"radius\"]\n}",
+        "requires_approval": 0,
+    },
 ]
 
 

--- a/ph_agent/ph_agent/doctype/tool_registry/tool_registry.json
+++ b/ph_agent/ph_agent/doctype/tool_registry/tool_registry.json
@@ -12,7 +12,6 @@
   "description",
   "python_function",
   "custom_script",
-  "server_script",
   "parameters_json",
   "requires_approval"
  ],
@@ -38,7 +37,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Script Type",
-   "options": "Existing Function\nCustom Script\nServer Script",
+   "options": "Existing Function\nCustom Script",
    "reqd": 1
   },
   {
@@ -60,14 +59,6 @@
    "label": "Custom Script",
    "mandatory_depends_on": "eval:doc.script_type == 'Custom Script'",
    "options": "Python"
-  },
-  {
-   "depends_on": "eval:doc.script_type == 'Server Script'",
-   "fieldname": "server_script",
-   "fieldtype": "Link",
-   "label": "Server Script",
-   "mandatory_depends_on": "eval:doc.script_type == 'Server Script'",
-   "options": "Server Script"
   },
   {
    "depends_on": "eval:doc.script_type != 'Existing Function'",

--- a/ph_agent/ph_agent/doctype/tool_registry/tool_registry.json
+++ b/ph_agent/ph_agent/doctype/tool_registry/tool_registry.json
@@ -8,8 +8,11 @@
  "field_order": [
   "tool_name",
   "is_enabled",
+  "script_type",
   "description",
   "python_function",
+  "custom_script",
+  "server_script",
   "parameters_json",
   "requires_approval"
  ],
@@ -30,17 +33,44 @@
    "label": "Enabled"
   },
   {
+   "default": "Existing Function",
+   "fieldname": "script_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Script Type",
+   "options": "Existing Function\nCustom Script\nServer Script",
+   "reqd": 1
+  },
+  {
    "fieldname": "description",
    "fieldtype": "Long Text",
    "label": "Description"
   },
   {
+   "depends_on": "eval:doc.script_type == 'Existing Function'",
    "fieldname": "python_function",
    "fieldtype": "Data",
    "label": "Python Function",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.script_type == 'Existing Function'"
   },
   {
+   "depends_on": "eval:doc.script_type == 'Custom Script'",
+   "fieldname": "custom_script",
+   "fieldtype": "Code",
+   "label": "Custom Script",
+   "mandatory_depends_on": "eval:doc.script_type == 'Custom Script'",
+   "options": "Python"
+  },
+  {
+   "depends_on": "eval:doc.script_type == 'Server Script'",
+   "fieldname": "server_script",
+   "fieldtype": "Link",
+   "label": "Server Script",
+   "mandatory_depends_on": "eval:doc.script_type == 'Server Script'",
+   "options": "Server Script"
+  },
+  {
+   "depends_on": "eval:doc.script_type != 'Existing Function'",
    "fieldname": "parameters_json",
    "fieldtype": "Code",
    "label": "Parameters JSON",

--- a/ph_agent/ph_agent/doctype/tool_registry/tool_registry.py
+++ b/ph_agent/ph_agent/doctype/tool_registry/tool_registry.py
@@ -80,8 +80,6 @@ class ToolRegistry(Document):
                         self._validate_function_path()
                 elif script_type == "Custom Script":
                         self._validate_custom_script()
-                elif script_type == "Server Script":
-                        self._validate_server_script_link()
 
                 # 3. Validate parameters_json is valid JSON
                 self._validate_parameters_json()
@@ -156,47 +154,6 @@ class ToolRegistry(Document):
                                 frappe._(
                                         "Custom Script must define a top-level callable function named 'run_tool' "
                                         "that serves as the tool entry point."
-                                )
-                        )
-
-        def _validate_server_script_link(self):
-                """Validate the linked Server Script exists, is enabled, and defines run_tool."""
-                if not self.server_script:
-                        frappe.throw(frappe._("Server Script is required when Script Type is 'Server Script'."))
-
-                if not frappe.db.exists("Server Script", self.server_script):
-                        frappe.throw(
-                                frappe._("Server Script '{0}' does not exist.").format(self.server_script)
-                        )
-
-                server_script_doc = frappe.get_doc("Server Script", self.server_script)
-
-                # Check the script content for a run_tool function
-                if not server_script_doc.script:
-                        frappe.throw(
-                                frappe._("Server Script '{0}' has no script content.").format(self.server_script)
-                        )
-
-                try:
-                        namespace = dict(SAFE_NAMESPACE_TEMPLATE)
-                        exec(server_script_doc.script, namespace)
-                        if "run_tool" not in namespace or not callable(namespace["run_tool"]):
-                                frappe.throw(
-                                        frappe._(
-                                                "Server Script '{0}' must define a top-level callable function "
-                                                "named 'run_tool'."
-                                        ).format(self.server_script)
-                                )
-                except SyntaxError as e:
-                        frappe.throw(
-                                frappe._("Server Script '{0}' contains syntax error at line {1}: {2}").format(
-                                        self.server_script, e.lineno, e.msg
-                                )
-                        )
-                except Exception as e:
-                        frappe.throw(
-                                frappe._("Server Script '{0}' raised error during validation: {1}").format(
-                                        self.server_script, str(e)
                                 )
                         )
 

--- a/ph_agent/ph_agent/doctype/tool_registry/tool_registry.py
+++ b/ph_agent/ph_agent/doctype/tool_registry/tool_registry.py
@@ -6,9 +6,11 @@ from frappe.model.document import Document
 
 
 # Safe namespace template for compiling custom/server scripts.
-# Provides controlled access to common modules without exposing dangerous builtins.
+# Provides controlled access to common modules.
+# __import__ is included so user scripts can use 'import math' etc.
 SAFE_NAMESPACE_TEMPLATE = {
     "__builtins__": {
+        "__import__": __import__,
         "abs": abs,
         "all": all,
         "any": any,

--- a/ph_agent/ph_agent/doctype/tool_registry/tool_registry.py
+++ b/ph_agent/ph_agent/doctype/tool_registry/tool_registry.py
@@ -5,68 +5,207 @@ import frappe
 from frappe.model.document import Document
 
 
+# Safe namespace template for compiling custom/server scripts.
+# Provides controlled access to common modules without exposing dangerous builtins.
+SAFE_NAMESPACE_TEMPLATE = {
+    "__builtins__": {
+        "abs": abs,
+        "all": all,
+        "any": any,
+        "bool": bool,
+        "callable": callable,
+        "chr": chr,
+        "dict": dict,
+        "divmod": divmod,
+        "enumerate": enumerate,
+        "filter": filter,
+        "float": float,
+        "format": format,
+        "frozenset": frozenset,
+        "getattr": getattr,
+        "hasattr": hasattr,
+        "hash": hash,
+        "hex": hex,
+        "id": id,
+        "int": int,
+        "isinstance": isinstance,
+        "issubclass": issubclass,
+        "iter": iter,
+        "len": len,
+        "list": list,
+        "map": map,
+        "max": max,
+        "min": min,
+        "next": next,
+        "object": object,
+        "oct": oct,
+        "ord": ord,
+        "pow": pow,
+        "print": print,
+        "range": range,
+        "repr": repr,
+        "reversed": reversed,
+        "round": round,
+        "set": set,
+        "slice": slice,
+        "sorted": sorted,
+        "str": str,
+        "sum": sum,
+        "tuple": tuple,
+        "type": type,
+        "zip": zip,
+    },
+    "math": __import__("math"),
+    "datetime": __import__("datetime"),
+    "json": __import__("json"),
+    "random": __import__("random"),
+    "re": __import__("re"),
+    "decimal": __import__("decimal"),
+    "statistics": __import__("statistics"),
+    "frappe": frappe,
+}
+
+
 class ToolRegistry(Document):
-	def validate(self):
-		"""Validate Tool Registry document."""
-		# 1. Validate tool_name uniqueness
-		self._validate_unique_name()
-		
-		# 2. Validate python_function is importable
-		self._validate_function_path()
-		
-		# 3. Validate parameters_json is valid JSON
-		self._validate_parameters_json()
-	
-	def _validate_unique_name(self):
-		"""Ensure tool_name is unique."""
-		if not self.tool_name:
-			return
-		
-		existing = frappe.get_list(
-			"Tool Registry",
-			filters={"tool_name": self.tool_name, "name": ("!=", self.name)},
-			pluck="name",
-		)
-		if existing:
-			frappe.throw(
-				frappe._("Tool name '{0}' already exists in record {1}").format(
-					self.tool_name, existing[0]
-				)
-			)
-	
-	def _validate_function_path(self):
-		"""Validate python_function path is valid and importable."""
-		if not self.python_function:
-			return
-		
-		parts = self.python_function.rsplit('.', 1)
-		if len(parts) != 2:
-			frappe.throw(
-				frappe._("Invalid function path: {0}. Expected format: 'module.submodule.function_name'").format(
-					self.python_function
-				)
-			)
-		
-		module_path, func_name = parts
-		try:
-			module = importlib.import_module(module_path)
-			func = getattr(module, func_name)
-			if not callable(func):
-				raise TypeError("Not callable")
-		except (ImportError, AttributeError, TypeError) as e:
-			frappe.throw(
-				frappe._("Cannot import function '{0}': {1}").format(self.python_function, str(e))
-			)
-	
-	def _validate_parameters_json(self):
-		"""Validate parameters_json is valid JSON."""
-		if not self.parameters_json:
-			return
-		
-		try:
-			json.loads(self.parameters_json)
-		except json.JSONDecodeError as e:
-			frappe.throw(
-				frappe._("Invalid JSON in parameters_json: {0}").format(str(e))
-			)
-	
+        def validate(self):
+                """Validate Tool Registry document."""
+                # 1. Validate tool_name uniqueness
+                self._validate_unique_name()
+
+                # 2. Validate script based on script_type
+                script_type = getattr(self, "script_type", "Existing Function")
+                if script_type == "Existing Function":
+                        self._validate_function_path()
+                elif script_type == "Custom Script":
+                        self._validate_custom_script()
+                elif script_type == "Server Script":
+                        self._validate_server_script_link()
+
+                # 3. Validate parameters_json is valid JSON
+                self._validate_parameters_json()
+
+        def _validate_unique_name(self):
+                """Ensure tool_name is unique."""
+                if not self.tool_name:
+                        return
+
+                existing = frappe.get_list(
+                        "Tool Registry",
+                        filters={"tool_name": self.tool_name, "name": ("!=", self.name)},
+                        pluck="name",
+                )
+                if existing:
+                        frappe.throw(
+                                frappe._("Tool name '{0}' already exists in record {1}").format(
+                                        self.tool_name, existing[0]
+                                )
+                        )
+
+        def _validate_function_path(self):
+                """Validate python_function path is valid and importable."""
+                if not self.python_function:
+                        return
+
+                parts = self.python_function.rsplit('.', 1)
+                if len(parts) != 2:
+                        frappe.throw(
+                                frappe._("Invalid function path: {0}. Expected format: 'module.submodule.function_name'").format(
+                                        self.python_function
+                                )
+                        )
+
+                module_path, func_name = parts
+                try:
+                        module = importlib.import_module(module_path)
+                        func = getattr(module, func_name)
+                        if not callable(func):
+                                raise TypeError("Not callable")
+                except (ImportError, AttributeError, TypeError) as e:
+                        frappe.throw(
+                                frappe._("Cannot import function '{0}': {1}").format(self.python_function, str(e))
+                        )
+
+        def _validate_custom_script(self):
+                """Validate custom_script contains valid Python with a run_tool function."""
+                if not self.custom_script:
+                        frappe.throw(frappe._("Custom Script is required when Script Type is 'Custom Script'."))
+
+                # Check Python syntax via compile()
+                try:
+                        compile(self.custom_script, "<custom_script>", "exec")
+                except SyntaxError as e:
+                        frappe.throw(
+                                frappe._("Custom Script contains syntax error at line {0}: {1}").format(
+                                        e.lineno, e.msg
+                                )
+                        )
+
+                # Check that run_tool is defined
+                namespace = dict(SAFE_NAMESPACE_TEMPLATE)
+                try:
+                        exec(self.custom_script, namespace)
+                except Exception as e:
+                        frappe.throw(
+                                frappe._("Custom Script raised an error during validation: {0}").format(str(e))
+                        )
+
+                if "run_tool" not in namespace or not callable(namespace["run_tool"]):
+                        frappe.throw(
+                                frappe._(
+                                        "Custom Script must define a top-level callable function named 'run_tool' "
+                                        "that serves as the tool entry point."
+                                )
+                        )
+
+        def _validate_server_script_link(self):
+                """Validate the linked Server Script exists, is enabled, and defines run_tool."""
+                if not self.server_script:
+                        frappe.throw(frappe._("Server Script is required when Script Type is 'Server Script'."))
+
+                if not frappe.db.exists("Server Script", self.server_script):
+                        frappe.throw(
+                                frappe._("Server Script '{0}' does not exist.").format(self.server_script)
+                        )
+
+                server_script_doc = frappe.get_doc("Server Script", self.server_script)
+
+                # Check the script content for a run_tool function
+                if not server_script_doc.script:
+                        frappe.throw(
+                                frappe._("Server Script '{0}' has no script content.").format(self.server_script)
+                        )
+
+                try:
+                        namespace = dict(SAFE_NAMESPACE_TEMPLATE)
+                        exec(server_script_doc.script, namespace)
+                        if "run_tool" not in namespace or not callable(namespace["run_tool"]):
+                                frappe.throw(
+                                        frappe._(
+                                                "Server Script '{0}' must define a top-level callable function "
+                                                "named 'run_tool'."
+                                        ).format(self.server_script)
+                                )
+                except SyntaxError as e:
+                        frappe.throw(
+                                frappe._("Server Script '{0}' contains syntax error at line {1}: {2}").format(
+                                        self.server_script, e.lineno, e.msg
+                                )
+                        )
+                except Exception as e:
+                        frappe.throw(
+                                frappe._("Server Script '{0}' raised error during validation: {1}").format(
+                                        self.server_script, str(e)
+                                )
+                        )
+
+        def _validate_parameters_json(self):
+                """Validate parameters_json is valid JSON."""
+                if not self.parameters_json:
+                        return
+
+                try:
+                        json.loads(self.parameters_json)
+                except json.JSONDecodeError as e:
+                        frappe.throw(
+                                frappe._("Invalid JSON in parameters_json: {0}").format(str(e))
+                        )


### PR DESCRIPTION
Introduce support for custom and server scripts in the Tool Registry, including validation and seeding of default tools. Add a new circle_calculator tool with a custom script for area and circumference calculations. Remove server script support from the Tool Registry and Tool Manager.