### PR TITLE
Auto-set user field to logged-in user in UserMemory and UserPreference

### DIFF
--- a/ph_agent/ph_agent/doctype/saved_prompt/saved_prompt.json
+++ b/ph_agent/ph_agent/doctype/saved_prompt/saved_prompt.json
@@ -15,6 +15,7 @@
  ],
  "fields": [
   {
+   "default": "__user",
    "fieldname": "user",
    "fieldtype": "Link",
    "in_list_view": 1,

--- a/ph_agent/ph_agent/doctype/user_memory/user_memory.json
+++ b/ph_agent/ph_agent/doctype/user_memory/user_memory.json
@@ -29,6 +29,7 @@
    "search_index": 1
   },
   {
+   "default": "__user",
    "fieldname": "user",
    "fieldtype": "Link",
    "in_list_view": 1,

--- a/ph_agent/ph_agent/doctype/user_memory/user_memory.py
+++ b/ph_agent/ph_agent/doctype/user_memory/user_memory.py
@@ -13,6 +13,11 @@ class UserMemory(Document):
 	fact increments ``encounter_count`` rather than creating duplicates.
 	"""
 
+	def before_insert(self) -> None:
+		"""Auto-set user to the logged-in user."""
+		if not self.user:
+			self.user = frappe.session.user
+
 	def before_save(self) -> None:
 		"""Auto-set last_encountered_at and normalize the fact field."""
 		self.fact = (self.fact or "").strip()

--- a/ph_agent/ph_agent/doctype/user_preference/user_preference.json
+++ b/ph_agent/ph_agent/doctype/user_preference/user_preference.json
@@ -11,6 +11,7 @@
  ],
  "fields": [
   {
+   "default": "__user",
    "fieldname": "user",
    "fieldtype": "Link",
    "in_list_view": 1,

--- a/ph_agent/ph_agent/doctype/user_preference/user_preference.py
+++ b/ph_agent/ph_agent/doctype/user_preference/user_preference.py
@@ -13,6 +13,11 @@ class UserPreference(Document):
 	Preferences are stored as a JSON dict in the ``preferences`` field.
 	"""
 
+	def before_insert(self) -> None:
+		"""Auto-set user to the logged-in user."""
+		if not self.user:
+			self.user = frappe.session.user
+
 	def before_save(self) -> None:
 		"""Ensure preferences is valid JSON on save."""
 		if self.preferences and isinstance(self.preferences, str):


### PR DESCRIPTION
Automatically assign the logged-in user to the user field in UserMemory and UserPreference when a new document is created, and set a default value in the JSON schema.