### PR TITLE
Streamline User Memory management by replacing set_value with delete

### DIFF
--- a/ph_agent/api/agent_jobs.py
+++ b/ph_agent/api/agent_jobs.py
@@ -356,13 +356,8 @@ def _call_agent_background(session, user_msg_name, content, file_names, enqueued
 	
 	# If regenerating, delete the old agent message before creating the new one
 	if agent_msg_name and frappe.db.exists("Chat Message", agent_msg_name):
-		# Clear User Memory references to this message to avoid LinkExistsError
-		frappe.db.set_value(
-			"User Memory",
-			{"source_message": agent_msg_name},
-			"source_message",
-			None,
-		)
+		# Delete User Memory records linked to this message
+		frappe.db.delete("User Memory", {"source_message": agent_msg_name})
 		frappe.delete_doc("Chat Message", agent_msg_name, ignore_permissions=True)
 		frappe.db.commit()
 	
@@ -1157,13 +1152,8 @@ def cancel_approvals_for_session(doc, method):
 	
 	Called via doc_events hook: Chat Session > on_trash
 	"""
-	# Clear User Memory source_session references to this session
-	frappe.db.set_value(
-		"User Memory",
-		{"source_session": doc.name},
-		"source_session",
-		None,
-	)
+	# Delete User Memory records linked to this session
+	frappe.db.delete("User Memory", {"source_session": doc.name})
 	
 	linked_requests = frappe.get_all(
 		"Tool Approval Request",
@@ -1189,13 +1179,8 @@ def cancel_approvals_for_message(doc, method):
 	
 	Called via doc_events hook: Chat Message > on_trash
 	"""
-	# Clear User Memory references to this message to avoid LinkExistsError
-	frappe.db.set_value(
-		"User Memory",
-		{"source_message": doc.name},
-		"source_message",
-		None,
-	)
+	# Delete User Memory records linked to this message
+	frappe.db.delete("User Memory", {"source_message": doc.name})
 	
 	# If this message is referenced as the session's last_summary_message,
 	# clear that reference to avoid LinkExistsError

--- a/ph_agent/api/chat.py
+++ b/ph_agent/api/chat.py
@@ -387,7 +387,7 @@ def delete_session(session):
 	For temporary sessions, this is called automatically when the user
 	navigates away. The function:
 	1. Cancels any running background job for this session
-	2. Clears User Memory references (source_message, source_session)
+	2. Deletes all User Memory records linked to this session or its messages
 	3. Clears Tool Approval Request references (chat_message, chat_session)
 	4. Clears the session's last_summary_message link
 	5. Deletes all Chat Messages (cascade deletes attached files)
@@ -417,20 +417,10 @@ def delete_session(session):
 		pluck="name",
 	)
 	
-	# 3. Clear User Memory references to avoid LinkExistsError
+	# 3. Delete all User Memory records linked to this session or its messages
+	frappe.db.delete("User Memory", {"source_session": session})
 	for message_id in messages:
-		frappe.db.set_value(
-			"User Memory",
-			{"source_message": message_id},
-			"source_message",
-			None,
-		)
-	frappe.db.set_value(
-		"User Memory",
-		{"source_session": session},
-		"source_session",
-		None,
-	)
+		frappe.db.delete("User Memory", {"source_message": message_id})
 
 	# 4. Clear Tool Approval Request references to avoid link validation errors
 	frappe.db.set_value(
@@ -502,13 +492,8 @@ def edit_message(message_id, content):
 	deleted_ids = []
 	for subsequent_msg in subsequent:
 		deleted_ids.append(subsequent_msg.name)
-		# Clear User Memory references to this message to avoid LinkExistsError
-		frappe.db.set_value(
-			"User Memory",
-			{"source_message": subsequent_msg.name},
-			"source_message",
-			None,
-		)
+		# Delete User Memory records linked to this message
+		frappe.db.delete("User Memory", {"source_message": subsequent_msg.name})
 		# Delete the chat message (on_trash hook will delete attached files)
 		frappe.delete_doc("Chat Message", subsequent_msg.name, ignore_permissions=True)
 
@@ -707,13 +692,8 @@ def delete_message(message_id):
 		# Clear the reference before deleting the message
 		frappe.db.set_value("Chat Session", session, "last_summary_message", None)
 	
-	# Clear User Memory references to this message to avoid LinkExistsError
-	frappe.db.set_value(
-		"User Memory",
-		{"source_message": message_id},
-		"source_message",
-		None,
-	)
+	# Delete User Memory records linked to this message
+	frappe.db.delete("User Memory", {"source_message": message_id})
 	frappe.db.commit()
 	
 	# Delete the chat message (on_trash hook will delete attached files)
@@ -751,13 +731,8 @@ def delete_messages(message_ids):
 			# Clear the reference before deleting the message
 			frappe.db.set_value("Chat Session", session, "last_summary_message", None)
 		
-		# Clear User Memory references to this message to avoid LinkExistsError
-		frappe.db.set_value(
-			"User Memory",
-			{"source_message": message_id},
-			"source_message",
-			None,
-		)
+		# Delete User Memory records linked to this message
+		frappe.db.delete("User Memory", {"source_message": message_id})
 		
 		# Delete the chat message (on_trash hook will delete attached files)
 		frappe.delete_doc("Chat Message", message_id, ignore_permissions=True)

--- a/ph_agent/ph_agent/tasks.py
+++ b/ph_agent/ph_agent/tasks.py
@@ -37,20 +37,10 @@ def cleanup_temporary_sessions():
 				pluck="name",
 			)
 
-			# Clear User Memory references
+			# Delete User Memory records linked to this session or its messages
 			for message_id in messages:
-				frappe.db.set_value(
-					"User Memory",
-					{"source_message": message_id},
-					"source_message",
-					None,
-				)
-			frappe.db.set_value(
-				"User Memory",
-				{"source_session": session_name},
-				"source_session",
-				None,
-			)
+				frappe.db.delete("User Memory", {"source_message": message_id})
+			frappe.db.delete("User Memory", {"source_session": session_name})
 
 			# Clear Tool Approval Request references
 			frappe.db.set_value(


### PR DESCRIPTION
Replace the use of `set_value` with `delete` for managing linked User Memory records, enhancing efficiency and preventing potential errors related to existing links. This change simplifies the cleanup process when messages or sessions are deleted.