### PR TITLE
Remove unnecessary error logging for web search and streaming fallback

### DIFF
--- a/ph_agent/agent/tools/web_search_tool.py
+++ b/ph_agent/agent/tools/web_search_tool.py
@@ -95,11 +95,6 @@ def web_search_tool(
             raw_results = list(ddgs.text(effective_query, **kwargs))
 
     except Exception as exc:
-        import frappe
-        frappe.log_error(
-            f"DuckDuckGo search error for '{query}': {str(exc)}",
-            "Web Search Error",
-        )
         return f"Error performing web search: {exc}"
 
     # Normalize results

--- a/ph_agent/api/agent_jobs.py
+++ b/ph_agent/api/agent_jobs.py
@@ -511,10 +511,6 @@ def _call_agent_background(session, user_msg_name, content, file_names, enqueued
 				
 			except Exception as stream_error:
 				# If streaming fails, fall back to non-streaming
-				frappe.log_error(
-					title=f"Streaming failed for session {session}, falling back to non-streaming",
-					message=str(stream_error)
-				)
 				# Reload agent_msg to avoid TimestampMismatchError (it was committed earlier)
 				agent_msg = frappe.get_doc("Chat Message", agent_msg.name)
 				# Fall back to non-streaming - update the existing placeholder


### PR DESCRIPTION
Eliminate redundant error logging for web search and streaming fallback to streamline the code and reduce noise in the logs.