### PR TITLE
Add close session functionality in chat window

### DIFF
--- a/ph_agent/api/chat.py
+++ b/ph_agent/api/chat.py
@@ -549,6 +549,75 @@ def close_session(session):
 
 
 @frappe.whitelist()
+def open_session(session):
+	"""Re-open a previously closed Chat Session.
+
+	Sets the session status back to "Open". The session state was
+	already cleared when it was closed, so it will be rebuilt from
+	conversation history on the next agent invocation.
+
+	Args:
+		session: Chat Session name to re-open.
+	"""
+	frappe.has_permission("Chat Session", doc=session, throw=True)
+
+	frappe.db.set_value("Chat Session", session, "status", "Open")
+	frappe.db.commit()
+
+	# Notify frontend
+	frappe.publish_realtime(
+		event="session_opened",
+		message={"session": session},
+		room="website",
+	)
+
+	return {"status": "ok"}
+
+
+@frappe.whitelist()
+def archive_session(session):
+	"""Archive a Chat Session.
+
+	Sets the session status to "Archived", clears session state, and
+	cancels any running background job. The session is hidden from the
+	default room list (filtered out by status != "Archived") but can
+	still be accessed directly.
+
+	Args:
+		session: Chat Session name to archive.
+	"""
+	frappe.has_permission("Chat Session", doc=session, throw=True)
+
+	# Cancel any running background job for this session
+	job_id = frappe.cache().get_value(f"ph_agent:job:{session}")
+	if job_id:
+		try:
+			from frappe.utils.background_jobs import get_redis_conn
+			from rq.command import send_stop_job_command
+			jid = job_id.decode() if isinstance(job_id, bytes) else job_id
+			send_stop_job_command(connection=get_redis_conn(), job_id=jid)
+		except Exception:
+			pass
+		frappe.cache().delete_value(f"ph_agent:job:{session}")
+	frappe.cache().delete_value(f"ph_agent:lock:{session}")
+	frappe.cache().set_value(f"ph_agent:cancel:{session}", True, expires_in_sec=60)
+
+	# Set status to Archived — the before_save hook on ChatSession clears session_state
+	frappe.db.set_value("Chat Session", session, "status", "Archived")
+	frappe.db.commit()
+
+	# Notify frontend
+	_emit_status(session, "")
+	frappe.publish_realtime(
+		event="session_archived",
+		message={"session": session},
+		room="website",
+	)
+
+	return {"status": "ok"}
+
+
+@frappe.whitelist()
 def edit_message(message_id, content):
 	"""Edit a user message, delete all subsequent messages, and re-run the agent."""
 	msg = frappe.get_doc("Chat Message", message_id)

--- a/ph_agent/api/chat.py
+++ b/ph_agent/api/chat.py
@@ -507,6 +507,48 @@ def delete_session(session):
 
 
 @frappe.whitelist()
+def close_session(session):
+	"""Close a Chat Session without deleting it.
+
+	Sets the session status to "Closed", clears session state, and
+	cancels any running background job. The session remains visible
+	in the room list but is marked as closed.
+
+	Args:
+		session: Chat Session name to close.
+	"""
+	frappe.has_permission("Chat Session", doc=session, throw=True)
+
+	# Cancel any running background job for this session
+	job_id = frappe.cache().get_value(f"ph_agent:job:{session}")
+	if job_id:
+		try:
+			from frappe.utils.background_jobs import get_redis_conn
+			from rq.command import send_stop_job_command
+			jid = job_id.decode() if isinstance(job_id, bytes) else job_id
+			send_stop_job_command(connection=get_redis_conn(), job_id=jid)
+		except Exception:
+			pass
+		frappe.cache().delete_value(f"ph_agent:job:{session}")
+	frappe.cache().delete_value(f"ph_agent:lock:{session}")
+	frappe.cache().set_value(f"ph_agent:cancel:{session}", True, expires_in_sec=60)
+
+	# Set status to Closed — the before_save hook on ChatSession clears session_state
+	frappe.db.set_value("Chat Session", session, "status", "Closed")
+	frappe.db.commit()
+
+	# Notify frontend
+	_emit_status(session, "")
+	frappe.publish_realtime(
+		event="session_closed",
+		message={"session": session},
+		room="website",
+	)
+
+	return {"status": "ok"}
+
+
+@frappe.whitelist()
 def edit_message(message_id, content):
 	"""Edit a user message, delete all subsequent messages, and re-run the agent."""
 	msg = frappe.get_doc("Chat Message", message_id)

--- a/ph_agent/ph_agent/page/chat/chat.js
+++ b/ph_agent/ph_agent/page/chat/chat.js
@@ -366,6 +366,7 @@ function initPhChat(container, page, $status) {
 	chat.setAttribute("messages-loaded", "false");
 	chat.setAttribute("room-actions", JSON.stringify([
 		{ name: "closeRoom", title: __("Close") },
+		{ name: "archiveRoom", title: __("Archive") },
 		{ name: "deleteRoom", title: __("Delete") }
 	]));
 	chat.setAttribute("message-actions", JSON.stringify([

--- a/ph_agent/ph_agent/page/chat/chat.js
+++ b/ph_agent/ph_agent/page/chat/chat.js
@@ -364,7 +364,10 @@ function initPhChat(container, page, $status) {
 	chat.setAttribute("show-audio", "false");
 	chat.setAttribute("rooms-loaded", "false");
 	chat.setAttribute("messages-loaded", "false");
-	chat.setAttribute("room-actions", JSON.stringify([{ name: "deleteRoom", title: __("Delete") }]));
+	chat.setAttribute("room-actions", JSON.stringify([
+		{ name: "closeRoom", title: __("Close") },
+		{ name: "deleteRoom", title: __("Delete") }
+	]));
 	chat.setAttribute("message-actions", JSON.stringify([
 		{ name: "editMessage", title: __("Edit"), onlyMe: true },
 		{ name: "deleteMessage", title: __("Delete") },

--- a/ph_agent/public/js/chat/modules/eventHandlers.js
+++ b/ph_agent/public/js/chat/modules/eventHandlers.js
@@ -116,6 +116,21 @@ window.phAgent.eventHandlers = window.phAgent.eventHandlers || (function() {
                 window._phSyncTempModeButton(!!room.isTemporary);
             }
             
+            // Update room-actions based on session status (Open vs Close)
+            const currentRoom = state.getRoomById(room.roomId);
+            if (currentRoom && currentRoom.status) {
+                // Access the private _updateRoomActions via the chat's room-actions attribute
+                const chat = document.querySelector("vue-advanced-chat");
+                if (chat) {
+                    const actions = [
+                        { name: currentRoom.status === "Closed" ? "openRoom" : "closeRoom", title: currentRoom.status === "Closed" ? __("Open") : __("Close") },
+                        { name: "archiveRoom", title: __("Archive") },
+                        { name: "deleteRoom", title: __("Delete") }
+                    ];
+                    chat.setAttribute("room-actions", JSON.stringify(actions));
+                }
+            }
+            
             // When switching away from a room that's mid-generation, the
             // agent_status("") event from the old room will be filtered out
             // (data.session !== _activeRoomId).  Clear the status bar and
@@ -949,6 +964,50 @@ window.phAgent.eventHandlers = window.phAgent.eventHandlers || (function() {
                                 .catch(err => {
                                     frappe.show_alert({ 
                                         message: __("Failed to close chat session"), 
+                                        indicator: "red" 
+                                    });
+                                });
+                        },
+                        () => {
+                            // User cancelled
+                        }
+                    );
+                    break;
+                    
+                case "openRoom":
+                    frappe.confirm(
+                        __("Re-open this chat session?"),
+                        () => {
+                            // User confirmed
+                            roomService.openRoom(roomId)
+                                .then(() => {
+                                    // Open was successful — alert shown in openRoom
+                                })
+                                .catch(err => {
+                                    frappe.show_alert({ 
+                                        message: __("Failed to re-open chat session"), 
+                                        indicator: "red" 
+                                    });
+                                });
+                        },
+                        () => {
+                            // User cancelled
+                        }
+                    );
+                    break;
+                    
+                case "archiveRoom":
+                    frappe.confirm(
+                        __("Are you sure you want to archive this chat session? It will be hidden from the room list."),
+                        () => {
+                            // User confirmed
+                            roomService.archiveRoom(roomId)
+                                .then(() => {
+                                    // Archive was successful — alert shown in archiveRoom
+                                })
+                                .catch(err => {
+                                    frappe.show_alert({ 
+                                        message: __("Failed to archive chat session"), 
                                         indicator: "red" 
                                     });
                                 });

--- a/ph_agent/public/js/chat/modules/eventHandlers.js
+++ b/ph_agent/public/js/chat/modules/eventHandlers.js
@@ -937,6 +937,28 @@ window.phAgent.eventHandlers = window.phAgent.eventHandlers || (function() {
             const actionName = action.name || action;
             
             switch (actionName) {
+                case "closeRoom":
+                    frappe.confirm(
+                        __("Are you sure you want to close this chat session? It will be marked as closed."),
+                        () => {
+                            // User confirmed
+                            roomService.closeRoom(roomId)
+                                .then(() => {
+                                    // Close was successful — alert shown in closeRoom
+                                })
+                                .catch(err => {
+                                    frappe.show_alert({ 
+                                        message: __("Failed to close chat session"), 
+                                        indicator: "red" 
+                                    });
+                                });
+                        },
+                        () => {
+                            // User cancelled
+                        }
+                    );
+                    break;
+                    
                 case "deleteRoom":
                     frappe.confirm(
                         __("Are you sure you want to delete this chat session? This action cannot be undone."),

--- a/ph_agent/public/js/chat/modules/roomService.js
+++ b/ph_agent/public/js/chat/modules/roomService.js
@@ -12,6 +12,23 @@ window.phAgent.roomService = window.phAgent.roomService || (function() {
     let _currentUserId = null;
     let _agentId = "ph_agent";
     
+    // ── Private helpers ────────────────────────────────────────────
+    
+    /**
+     * Update the room-actions attribute on the chat component based on session status.
+     * Closed sessions show "Open" instead of "Close".
+     * @param {string} status - "Open" or "Closed"
+     */
+    function _updateRoomActions(status) {
+        if (!_chat) return;
+        const actions = [
+            { name: status === "Closed" ? "openRoom" : "closeRoom", title: status === "Closed" ? __("Open") : __("Close") },
+            { name: "archiveRoom", title: __("Archive") },
+            { name: "deleteRoom", title: __("Delete") }
+        ];
+        _chat.setAttribute("room-actions", JSON.stringify(actions));
+    }
+    
     // Public API
     return {
         // --- Initialization ---
@@ -76,6 +93,7 @@ window.phAgent.roomService = window.phAgent.roomService || (function() {
                             roomId: s.name,
                             roomName: roomName,
                             isTemporary: !!s.is_temporary,
+                            status: s.status,
                             users: [
                                 { _id: _currentUserId, username: frappe.boot.user.full_name || _currentUserId },
                                 { _id: _agentId, username: "AI Agent" },
@@ -153,6 +171,7 @@ window.phAgent.roomService = window.phAgent.roomService || (function() {
                             roomId: session.session,
                             roomName: roomName,
                             isTemporary: !!session.is_temporary,
+                            status: "Open",
                             users: [
                                 { _id: _currentUserId, username: frappe.boot.user.full_name || _currentUserId },
                                 { _id: _agentId, username: "AI Agent" },
@@ -250,11 +269,15 @@ window.phAgent.roomService = window.phAgent.roomService || (function() {
                                 // Add closed indicator to room name if not already present
                                 if (!room.roomName.includes("🔒")) {
                                     state.updateRoom(roomId, {
-                                        roomName: "🔒 " + room.roomName
+                                        roomName: "🔒 " + room.roomName,
+                                        status: "Closed"
                                     });
                                     _chat.rooms = state.getRooms();
                                 }
                             }
+                            
+                            // Update room-actions to show Open instead of Close
+                            _updateRoomActions("Closed");
                             
                             frappe.show_alert({
                                 message: __("Chat session closed"),
@@ -267,6 +290,94 @@ window.phAgent.roomService = window.phAgent.roomService || (function() {
                     },
                     error: (err) => {
                         console.error("Failed to close room:", err);
+                        reject(err);
+                    }
+                });
+            });
+        },
+        
+        /**
+         * Re-open a previously closed room (chat session)
+         * @param {string} roomId - ID of the room to re-open
+         * @returns {Promise} Promise that resolves when room is opened
+         */
+        openRoom: function(roomId) {
+            return new Promise((resolve, reject) => {
+                frappe.call({
+                    method: "ph_agent.api.chat.open_session",
+                    args: { session: roomId },
+                    callback: (r) => {
+                        if (r.message && r.message.status === "ok") {
+                            // Update room name to remove closed indicator
+                            const state = window.phAgent.state;
+                            const room = state.getRoomById(roomId);
+                            if (room) {
+                                // Remove 🔒 prefix and update status
+                                const newName = room.roomName.replace(/^🔒 /, "");
+                                state.updateRoom(roomId, {
+                                    roomName: newName,
+                                    status: "Open"
+                                });
+                                _chat.rooms = state.getRooms();
+                            }
+                            
+                            // Update room-actions to show Close instead of Open
+                            _updateRoomActions("Open");
+                            
+                            frappe.show_alert({
+                                message: __("Chat session reopened"),
+                                indicator: "green"
+                            });
+                            resolve();
+                        } else {
+                            reject(new Error("Failed to open room"));
+                        }
+                    },
+                    error: (err) => {
+                        console.error("Failed to open room:", err);
+                        reject(err);
+                    }
+                });
+            });
+        },
+        
+        /**
+         * Archive a room (chat session) — hides it from the default room list
+         * @param {string} roomId - ID of the room to archive
+         * @returns {Promise} Promise that resolves when room is archived
+         */
+        archiveRoom: function(roomId) {
+            return new Promise((resolve, reject) => {
+                frappe.call({
+                    method: "ph_agent.api.chat.archive_session",
+                    args: { session: roomId },
+                    callback: (r) => {
+                        if (r.message && r.message.status === "ok") {
+                            // Remove room from state (it's hidden from the list)
+                            const state = window.phAgent.state;
+                            state.removeRoom(roomId);
+                            state.removeRoomProvider(roomId);
+                            
+                            // Update chat component
+                            _chat.rooms = state.getRooms();
+                            
+                            // If archived room was active, clear active room
+                            if (state.getActiveRoomId() === roomId) {
+                                state.setActiveRoomId(null);
+                                _chat.setAttribute("room-id", "");
+                            }
+                            
+                            frappe.show_alert({
+                                message: __("Chat session archived"),
+                                indicator: "blue"
+                            });
+                            resolve();
+                        } else {
+                            reject(new Error("Failed to archive room"));
+                        }
+                    },
+                    error: (err) => {
+                        console.error("Failed to archive room:", err);
                         reject(err);
                     }
                 });

--- a/ph_agent/public/js/chat/modules/roomService.js
+++ b/ph_agent/public/js/chat/modules/roomService.js
@@ -54,7 +54,7 @@ window.phAgent.roomService = window.phAgent.roomService || (function() {
             return frappe.db
                 .get_list("Chat Session", {
                     filters: filters,
-                    fields: ["name", "title", "modified", "llm_provider", "is_temporary"],
+                    fields: ["name", "title", "modified", "llm_provider", "is_temporary", "status"],
                     order_by: "modified desc",
                     limit: 50,
                 })
@@ -67,6 +67,9 @@ window.phAgent.roomService = window.phAgent.roomService || (function() {
                         let roomName = s.title + " — " + s.llm_provider;
                         if (s.is_temporary) {
                             roomName = "👻 " + roomName + " (Temporary)";
+                        }
+                        if (s.status === "Closed") {
+                            roomName = "🔒 " + roomName;
                         }
                         
                         return {
@@ -222,6 +225,48 @@ window.phAgent.roomService = window.phAgent.roomService || (function() {
                     },
                     error: (err) => {
                         console.error("Failed to delete room:", err);
+                        reject(err);
+                    }
+                });
+            });
+        },
+        
+        /**
+         * Close a room (chat session) without deleting it
+         * @param {string} roomId - ID of the room to close
+         * @returns {Promise} Promise that resolves when room is closed
+         */
+        closeRoom: function(roomId) {
+            return new Promise((resolve, reject) => {
+                frappe.call({
+                    method: "ph_agent.api.chat.close_session",
+                    args: { session: roomId },
+                    callback: (r) => {
+                        if (r.message && r.message.status === "ok") {
+                            // Update room name to indicate closed status
+                            const state = window.phAgent.state;
+                            const room = state.getRoomById(roomId);
+                            if (room) {
+                                // Add closed indicator to room name if not already present
+                                if (!room.roomName.includes("🔒")) {
+                                    state.updateRoom(roomId, {
+                                        roomName: "🔒 " + room.roomName
+                                    });
+                                    _chat.rooms = state.getRooms();
+                                }
+                            }
+                            
+                            frappe.show_alert({
+                                message: __("Chat session closed"),
+                                indicator: "blue"
+                            });
+                            resolve();
+                        } else {
+                            reject(new Error("Failed to close room"));
+                        }
+                    },
+                    error: (err) => {
+                        console.error("Failed to close room:", err);
                         reject(err);
                     }
                 });


### PR DESCRIPTION
Implement a new feature to allow users to close chat sessions without deletion. The close session option is added to the dropdown alongside the delete option. This change enhances user experience by providing more control over chat session management.

Fixes #93