### PR TITLE
Add real-time notifications for pruned messages in chat

### DIFF
--- a/ph_agent/api/agent_jobs.py
+++ b/ph_agent/api/agent_jobs.py
@@ -163,6 +163,7 @@ def _emergency_prune_messages(session: str, target_percentage: int = 80) -> int:
 
 	last_summary = session_doc.last_summary_message
 	deleted_count = 0
+	deleted_ids = []
 
 	while True:
 		total_tokens, _ = _get_total_estimated_tokens(session)
@@ -192,6 +193,7 @@ def _emergency_prune_messages(session: str, target_percentage: int = 80) -> int:
 		oldest = remaining[0]
 		try:
 			frappe.delete_doc("Chat Message", oldest["name"], ignore_permissions=True)
+			deleted_ids.append(oldest["name"])
 			deleted_count += 1
 		except Exception:
 			# If one fails, skip it
@@ -199,7 +201,27 @@ def _emergency_prune_messages(session: str, target_percentage: int = 80) -> int:
 
 	if deleted_count:
 		frappe.db.commit()
-		# Recompute and publish a token update
+
+		# Remove pruned messages from the frontend chat UI
+		frappe.publish_realtime(
+			event="messages_deleted",
+			message={"session": session, "message_ids": deleted_ids},
+			room="website",
+		)
+
+		# Notify the user that messages were pruned
+		frappe.publish_realtime(
+			event="messages_pruned",
+			message={
+				"session": session,
+				"count": deleted_count,
+				"percentage": round(token_percentage),
+				"message": f"To prevent context overload, {deleted_count} old message{'s' if deleted_count != 1 else ''} {'were' if deleted_count != 1 else 'was'} removed from the conversation. Consider summarizing to avoid losing messages in the future.",
+			},
+			room="website",
+		)
+
+		# Reset token display
 		frappe.publish_realtime(
 			event="token_update",
 			message={

--- a/ph_agent/public/js/chat/modules/realtimeListeners.js
+++ b/ph_agent/public/js/chat/modules/realtimeListeners.js
@@ -81,6 +81,7 @@ window.phAgent.realtimeListeners = window.phAgent.realtimeListeners || (function
             frappe.realtime.on("reasoning_chunk", this.handleReasoningChunk.bind(this));
             frappe.realtime.on("token_update", this.handleTokenUpdate.bind(this));
             frappe.realtime.on("token_warning", this.handleTokenWarning.bind(this));
+            frappe.realtime.on("messages_pruned", this.handleMessagesPruned.bind(this));
         },
         
         /**
@@ -148,8 +149,9 @@ window.phAgent.realtimeListeners = window.phAgent.realtimeListeners || (function
             frappe.realtime.off("suggestions_ready");
             frappe.realtime.off("message_chunk");
             frappe.realtime.off("reasoning_chunk");
+            frappe.realtime.off("messages_pruned");
         },
-        
+
         // --- Stop Button Handler ---
         
         /**
@@ -656,7 +658,20 @@ window.phAgent.realtimeListeners = window.phAgent.realtimeListeners || (function
             // Also update token counter
             this.handleTokenUpdate(data);
         },
-        
+
+        /**
+         * Handle messages_pruned event
+         * @param {Object} data - Event data with session, count, percentage, message
+         */
+        handleMessagesPruned: function(data) {
+            if (data.session !== _activeRoomId) return;
+
+            frappe.show_alert({
+                message: data.message || `${data.count} old messages were removed to free context space.`,
+                indicator: "orange"
+            }, 10);
+        },
+
         // --- Utility Methods ---
         
         /**


### PR DESCRIPTION
Implement real-time notifications to inform users when messages are pruned to manage context overload. This includes updates to the frontend to display alerts about the number of messages removed.