### PR TITLE
Centralize MIME type to extension mapping in utils

### DIFF
--- a/ph_agent/api/agent_jobs.py
+++ b/ph_agent/api/agent_jobs.py
@@ -472,7 +472,7 @@ def _call_agent_background(session, content, file_names, enqueued_by, agent_msg_
 
 			agent_content = re.sub(
 				r"\{\{\w+\}\}",
-				combined_text,
+				lambda m: combined_text,
 				content,
 			)
 			# If no {{variable}} placeholders were found, append text at end

--- a/ph_agent/public/js/chat/modules/eventHandlers.js
+++ b/ph_agent/public/js/chat/modules/eventHandlers.js
@@ -250,28 +250,8 @@ window.phAgent.eventHandlers = window.phAgent.eventHandlers || (function() {
             // Create optimistic user message
             const tempId = "temp_" + Date.now();
             
-            // Common MIME type to extension mapping (shared with handleOpenFile)
-            const mimeTypeToExtension = {
-                'application/pdf': 'pdf',
-                'application/msword': 'doc',
-                'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
-                'application/vnd.ms-excel': 'xls',
-                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
-                'application/vnd.ms-powerpoint': 'ppt',
-                'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
-                'text/plain': 'txt',
-                'text/csv': 'csv',
-                'text/html': 'html',
-                'application/json': 'json',
-                'application/xml': 'xml',
-                'application/epub+zip': 'epub',
-                'image/jpeg': 'jpg',
-                'image/jpg': 'jpg',
-                'image/png': 'png',
-                'image/gif': 'gif',
-                'image/svg+xml': 'svg'
-            };
-            
+            const mimeToExt = window.phAgent.utils.MIME_TYPE_TO_EXTENSION;
+
             const localFiles = (files || []).map((f) => {
                 // Try to get URL from different possible properties
                 // Vue Advanced Chat might provide file objects with different structures
@@ -286,9 +266,9 @@ window.phAgent.eventHandlers = window.phAgent.eventHandlers || (function() {
                 // Extract extension from MIME type or filename
                 let extension = "";
                 if (mimeType && mimeType.includes('/')) {
-                    // Check MIME type mapping first
-                    if (mimeTypeToExtension[mimeType]) {
-                        extension = mimeTypeToExtension[mimeType];
+                    const mimeLower = mimeType.toLowerCase();
+                    if (mimeToExt[mimeLower]) {
+                        extension = mimeToExt[mimeLower];
                     } else {
                         // Extract from MIME type (e.g., "application/pdf" -> "pdf")
                         extension = mimeType.split('/').pop();
@@ -394,34 +374,14 @@ window.phAgent.eventHandlers = window.phAgent.eventHandlers || (function() {
                                             }
                                         }
                                         
-                                        // Common MIME type to extension mapping (shared)
-                                        const mimeTypeToExtension = {
-                                            'application/pdf': 'pdf',
-                                            'application/msword': 'doc',
-                                            'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
-                                            'application/vnd.ms-excel': 'xls',
-                                            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
-                                            'application/vnd.ms-powerpoint': 'ppt',
-                                            'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
-                                            'text/plain': 'txt',
-                                            'text/csv': 'csv',
-                                            'text/html': 'html',
-                                            'application/json': 'json',
-                                            'application/xml': 'xml',
-                                            'application/epub+zip': 'epub',
-                                            'image/jpeg': 'jpg',
-                                            'image/jpg': 'jpg',
-                                            'image/png': 'png',
-                                            'image/gif': 'gif',
-                                            'image/svg+xml': 'svg'
-                                        };
-                                        
+                                        const mimeToExt = window.phAgent.utils.MIME_TYPE_TO_EXTENSION;
+
                                         // Get extension from MIME type or filename
                                         let extension = "";
                                         if (uploadedFile.file_type) {
-                                            // Check MIME type mapping first
-                                            if (mimeTypeToExtension[uploadedFile.file_type]) {
-                                                extension = mimeTypeToExtension[uploadedFile.file_type];
+                                            const mimeLower = uploadedFile.file_type.toLowerCase();
+                                            if (mimeToExt[mimeLower]) {
+                                                extension = mimeToExt[mimeLower];
                                             } else {
                                                 extension = uploadedFile.file_type.split('/').pop().toLowerCase();
                                             }
@@ -1124,37 +1084,16 @@ window.phAgent.eventHandlers = window.phAgent.eventHandlers || (function() {
                 
 
                 
-                // Common MIME type to extension mapping
-                const mimeTypeToExtension = {
-                    'application/pdf': 'pdf',
-                    'application/msword': 'doc',
-                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
-                    'application/vnd.ms-excel': 'xls',
-                    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
-                    'application/vnd.ms-powerpoint': 'ppt',
-                    'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
-                    'text/plain': 'txt',
-                    'text/csv': 'csv',
-                    'text/html': 'html',
-                    'application/json': 'json',
-                    'application/xml': 'xml',
-                    'application/epub+zip': 'epub',
-                    'image/jpeg': 'jpg',
-                    'image/jpg': 'jpg',
-                    'image/png': 'png',
-                    'image/gif': 'gif',
-                    'image/svg+xml': 'svg'
-                };
-                
+                const mimeToExt = window.phAgent.utils.MIME_TYPE_TO_EXTENSION;
+
                 // If fileName doesn't have extension but we have fileExtension, add it
                 if (fileName && fileExtension && !fileName.includes('.')) {
                     // Remove any leading dot from extension and convert to lowercase
                     fileExtension = fileExtension.replace(/^\./, '').toLowerCase();
-                    
+
                     // Check if fileExtension is a MIME type (contains '/')
                     if (fileExtension.includes('/')) {
-                        // It's a MIME type, look up extension
-                        const mappedExtension = mimeTypeToExtension[fileExtension];
+                        const mappedExtension = mimeToExt[fileExtension];
                         if (mappedExtension) {
                             fileExtension = mappedExtension;
                         } else {

--- a/ph_agent/public/js/chat/modules/utils.js
+++ b/ph_agent/public/js/chat/modules/utils.js
@@ -7,8 +7,32 @@
 
 // Initialize utils object if it doesn't exist
 window.phAgent.utils = window.phAgent.utils || (function() {
+    // Shared MIME type to extension mapping
+    const MIME_TYPE_TO_EXTENSION = {
+        'application/pdf': 'pdf',
+        'application/msword': 'doc',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+        'application/vnd.ms-excel': 'xls',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+        'application/vnd.ms-powerpoint': 'ppt',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
+        'text/plain': 'txt',
+        'text/csv': 'csv',
+        'text/html': 'html',
+        'application/json': 'json',
+        'application/xml': 'xml',
+        'application/epub+zip': 'epub',
+        'image/jpeg': 'jpg',
+        'image/jpg': 'jpg',
+        'image/png': 'png',
+        'image/gif': 'gif',
+        'image/svg+xml': 'svg'
+    };
+
     // Public API
     return {
+        // Expose the shared MIME map for other modules
+        MIME_TYPE_TO_EXTENSION: MIME_TYPE_TO_EXTENSION,
         // --- Message Formatting ---
         
         /**
@@ -47,31 +71,8 @@ window.phAgent.utils = window.phAgent.utils || (function() {
                 
                 // If no extension in filename, try to get from file_type (MIME type)
                 if (!extension && f.file_type) {
-                    // Common MIME type to extension mapping (same as in eventHandlers.js)
-                    const mimeTypeToExtension = {
-                        'application/pdf': 'pdf',
-                        'application/msword': 'doc',
-                        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
-                        'application/vnd.ms-excel': 'xls',
-                        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
-                        'application/vnd.ms-powerpoint': 'ppt',
-                        'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
-                        'text/plain': 'txt',
-                        'text/csv': 'csv',
-                        'text/html': 'html',
-                        'application/json': 'json',
-                        'application/xml': 'xml',
-                        'application/epub+zip': 'epub',
-                        'image/jpeg': 'jpg',
-                        'image/jpg': 'jpg',
-                        'image/png': 'png',
-                        'image/gif': 'gif',
-                        'image/svg+xml': 'svg'
-                    };
-                    
-                    // Extract MIME type and look up extension
                     const mimeType = f.file_type.toLowerCase();
-                    extension = mimeTypeToExtension[mimeType];
+                    extension = MIME_TYPE_TO_EXTENSION[mimeType];
                     
                     if (!extension) {
                         // If not in mapping, extract from MIME type (e.g., "application/pdf" -> "pdf")
@@ -162,33 +163,11 @@ window.phAgent.utils = window.phAgent.utils || (function() {
                 // Ensure filename has extension
                 const mimeType = fileBlob.type || "";
                 let extension = "";
-                
-                // Common MIME type to extension mapping
-                const mimeTypeToExtension = {
-                    'application/pdf': 'pdf',
-                    'application/msword': 'doc',
-                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
-                    'application/vnd.ms-excel': 'xls',
-                    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
-                    'application/vnd.ms-powerpoint': 'ppt',
-                    'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
-                    'text/plain': 'txt',
-                    'text/csv': 'csv',
-                    'text/html': 'html',
-                    'application/json': 'json',
-                    'application/xml': 'xml',
-                    'application/epub+zip': 'epub',
-                    'image/jpeg': 'jpg',
-                    'image/jpg': 'jpg',
-                    'image/png': 'png',
-                    'image/gif': 'gif',
-                    'image/svg+xml': 'svg'
-                };
-                
+
                 if (mimeType && mimeType.includes('/')) {
-                    // Check MIME type mapping first
-                    if (mimeTypeToExtension[mimeType]) {
-                        extension = mimeTypeToExtension[mimeType];
+                    const mimeLower = mimeType.toLowerCase();
+                    if (MIME_TYPE_TO_EXTENSION[mimeLower]) {
+                        extension = MIME_TYPE_TO_EXTENSION[mimeLower];
                     } else {
                         extension = mimeType.split('/').pop().toLowerCase();
                     }


### PR DESCRIPTION
Refactor the MIME type to extension mapping into a centralized utility for improved maintainability and consistency across the application. This change eliminates redundancy and enhances code clarity.